### PR TITLE
CWL workflow fastq2fasta/bam2fasta

### DIFF
--- a/cwl/bam2fasta.cwl
+++ b/cwl/bam2fasta.cwl
@@ -15,9 +15,6 @@ inputs:
   threads:
     type: int
     default: 4
-  freebayes_max_coverage:
-    type: int
-    default: 200
 
 outputs:
   out_fasta:
@@ -29,7 +26,6 @@ steps:
     in:
       bam: bam
       ref_fasta: fasta
-      max_coverage: freebayes_max_coverage
     out: [vcf]
     run: freebayes.cwl
   bcftools_view_exclude_ref:

--- a/cwl/bam2fasta.cwl
+++ b/cwl/bam2fasta.cwl
@@ -1,0 +1,71 @@
+# Reference:
+#  https://github.com/VGP/vgp-assembly/blob/33cd6236a68a1aee5f282e365dfe6b97e0b4ebb7/pipeline/freebayes-polish/freebayes.sh
+#  https://github.com/VGP/vgp-assembly/blob/33cd6236a68a1aee5f282e365dfe6b97e0b4ebb7/pipeline/freebayes-polish/consensus.sh
+class: Workflow
+cwlVersion: v1.1
+id: bam2fasta
+label: bam2fasta
+requirements: []
+
+inputs:
+  bam:
+    type: File
+  fasta:
+    type: File
+  threads:
+    type: int
+    default: 4
+  freebayes_max_coverage:
+    type: int
+    default: 200
+
+outputs:
+  out_fasta:
+    type: File
+    outputSource: bcftools_consensus/out_fasta
+
+steps:
+  freebayes:
+    in:
+      bam: bam
+      ref_fasta: fasta
+      max_coverage: freebayes_max_coverage
+    out: [vcf]
+    run: freebayes.cwl
+  bcftools_view_exclude_ref:
+    in:
+      vcf: freebayes/vcf
+      threads: threads
+    out: [bcf]
+    run: bcftools-view-exclude-ref.cwl
+  bcftools_norm:
+    in:
+      ref_fasta: fasta
+      bcf: bcftools_view_exclude_ref/bcf
+      threads: threads
+    out: [normalized_bcf]
+    run: bcftools-norm.cwl
+  bcftools_index_after_normalization:
+    in:
+      bcf: bcftools_norm/normalized_bcf
+    out: [index]
+    run: bcftools-index.cwl
+  bcftools_view_qc:
+    in:
+      bcf: bcftools_norm/normalized_bcf
+      bcf_index: bcftools_index_after_normalization/index
+      threads: threads
+    out: [vcf]
+    run: bcftools-view-qc.cwl
+  bcftools_index_after_qc:
+    in:
+      bcf: bcftools_view_qc/vcf
+    out: [index]
+    run: bcftools-index.cwl
+  bcftools_consensus:
+    in:
+      ref_fasta: fasta
+      vcf: bcftools_view_qc/vcf
+      vcf_index: bcftools_index_after_qc/index
+    out: [out_fasta]
+    run: bcftools-consensus.cwl

--- a/cwl/bcftools-concat.cwl
+++ b/cwl/bcftools-concat.cwl
@@ -1,0 +1,24 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+hints:
+  DockerRequirement:
+    dockerPull: "quay.io/biocontainers/bcftools:1.10.2--hd2cd319_0"
+baseCommand: bcftools
+arguments:
+  - concat
+  - -Ou
+  - -o
+  - $(inputs.output_name)
+  - $(inputs.bcf_files)
+inputs:
+  - id: output_name
+    type: string
+    default: "merged.bcf"
+  - id: bcf_files
+    type: File[]
+outputs:
+  - id: merged_bcf
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_name)"

--- a/cwl/bcftools-consensus.cwl
+++ b/cwl/bcftools-consensus.cwl
@@ -12,7 +12,7 @@ requirements:
 baseCommand: bcftools
 arguments:
   - consensus
-  - -i'QUAL>1 && (GT="AA" || GT="Aa")'
+  - -i'QUAL > 1 && GT="A"'
   - -Hla
   - -f
   - $(inputs.ref_fasta)

--- a/cwl/bcftools-consensus.cwl
+++ b/cwl/bcftools-consensus.cwl
@@ -1,0 +1,30 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+hints:
+  DockerRequirement:
+    dockerPull: "quay.io/biocontainers/bcftools:1.10.2--hd2cd319_0"
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - $(inputs.vcf)
+      - $(inputs.vcf_index)
+baseCommand: bcftools
+arguments:
+  - consensus
+  - -i'QUAL>1 && (GT="AA" || GT="Aa")'
+  - -Hla
+  - -f
+  - $(inputs.ref_fasta)
+  - $(inputs.vcf)
+inputs:
+  - id: ref_fasta
+    type: File
+  - id: vcf
+    type: File
+  - id: vcf_index
+    type: File
+outputs:
+  - id: out_fasta
+    type: stdout
+stdout: out.fasta

--- a/cwl/bcftools-index.cwl
+++ b/cwl/bcftools-index.cwl
@@ -1,0 +1,18 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+hints:
+  DockerRequirement:
+    dockerPull: "quay.io/biocontainers/bcftools:1.10.2--hd2cd319_0"
+baseCommand: bcftools
+arguments:
+  - index
+  - $(inputs.bcf)
+inputs:
+  - id: bcf
+    type: File
+outputs:
+  - id: index
+    type: File
+    outputBinding:
+      glob: "$(inputs.bcf).csi"

--- a/cwl/bcftools-norm.cwl
+++ b/cwl/bcftools-norm.cwl
@@ -1,0 +1,32 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+hints:
+  DockerRequirement:
+    dockerPull: "quay.io/biocontainers/bcftools:1.10.2--hd2cd319_0"
+baseCommand: bcftools
+arguments:
+  - norm
+  - -Ob
+  - -f
+  - $(inputs.ref_fasta)
+  - -o
+  - $(inputs.output_name)
+  - --threads
+  - $(inputs.threads)
+  - $(inputs.bcf)
+inputs:
+  - id: ref_fasta
+    type: File
+  - id: output_name
+    type: string
+    default: "normalized.bcf"
+  - id: threads
+    type: int
+  - id: bcf
+    type: File
+outputs:
+ - id: normalized_bcf
+   type: File
+   outputBinding:
+     glob: "$(inputs.output_name)"

--- a/cwl/bcftools-view-exclude-ref.cwl
+++ b/cwl/bcftools-view-exclude-ref.cwl
@@ -1,0 +1,23 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+hints:
+  DockerRequirement:
+    dockerPull: "quay.io/biocontainers/bcftools:1.10.2--hd2cd319_0"
+baseCommand: bcftools
+arguments:
+  - view
+  - --no-version
+  - -Ou
+  - -e'type=ref'
+  - --threads=$(inputs.threads)
+  - $(inputs.vcf)
+inputs:
+  - id: vcf
+    type: File
+  - id: threads
+    type: int
+outputs:
+  - id: bcf
+    type: stdout
+stdout: $(inputs.bcf.nameroot).without-ref.bcf

--- a/cwl/bcftools-view-qc.cwl
+++ b/cwl/bcftools-view-qc.cwl
@@ -1,0 +1,30 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+hints:
+  DockerRequirement:
+    dockerPull: "quay.io/biocontainers/bcftools:1.10.2--hd2cd319_0"
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - $(inputs.bcf)
+      - $(inputs.bcf_index)
+baseCommand: bcftools
+arguments:
+  - view
+  - -i
+  - 'QUAL>1 && (GT="AA" || GT="Aa")'
+  - -Oz
+  - --threads=$(inputs.threads)
+  - $(inputs.bcf)
+inputs:
+  - id: threads
+    type: int
+  - id: bcf
+    type: File
+  - id: bcf_index
+    type: File
+outputs:
+  - id: vcf
+    type: stdout
+stdout: out.changes.vcf.gz

--- a/cwl/bcftools-view.cwl
+++ b/cwl/bcftools-view.cwl
@@ -1,0 +1,19 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+hints:
+  DockerRequirement:
+    dockerPull: "quay.io/biocontainers/bcftools:1.10.2--hd2cd319_0"
+baseCommand: bcftools
+arguments:
+  - view
+  - --no-version
+  - -Ou
+  - $(inputs.vcf)
+inputs:
+  - id: vcf
+    type: File
+outputs:
+  - id: bcf
+    type: stdout
+stdout: $(inputs.vcf.nameroot).bcf

--- a/cwl/bwa-index.cwl
+++ b/cwl/bwa-index.cwl
@@ -1,0 +1,42 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.1
+class: CommandLineTool
+doc: string
+requirements:
+  DockerRequirement:
+    dockerPull: quay.io/biocontainers/bwa:0.7.17--h84994c4_5
+  InitialWorkDirRequirement:
+    listing:
+      - $(inputs.input_fasta)
+baseCommand: [bwa, index]
+inputs:
+  input_fasta:
+    type: File
+    label: "input fasta file"
+    inputBinding:
+      position: 1
+outputs:
+  amb:
+    type: File
+    outputBinding:
+      glob: $(inputs.input_fasta.basename).amb
+  ann:
+    type: File
+    outputBinding:
+      glob: $(inputs.input_fasta.basename).ann
+  bwt:
+    type: File
+    outputBinding:
+      glob: $(inputs.input_fasta.basename).bwt
+  pac:
+    type: File
+    outputBinding:
+      glob: $(inputs.input_fasta.basename).pac
+  sa:
+    type: File
+    outputBinding:
+      glob: $(inputs.input_fasta.basename).sa
+  stdout: stdout
+  stderr: stderr
+stdout: bwa-index-stdout.log
+stderr: bwa-index-stderr.log

--- a/cwl/bwa-mem.cwl
+++ b/cwl/bwa-mem.cwl
@@ -1,0 +1,71 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.1
+class: CommandLineTool
+doc: string
+requirements:
+  DockerRequirement:
+    dockerPull: quay.io/biocontainers/bwa:0.7.17--h84994c4_5
+  InitialWorkDirRequirement:
+    listing:
+      - $(inputs.index_base)
+      - $(inputs.amb)
+      - $(inputs.ann)
+      - $(inputs.bwt)
+      - $(inputs.pac)
+      - $(inputs.sa)
+
+baseCommand: [bwa, mem]
+
+inputs:
+  threads:
+    type: int
+    label: "number of threads"
+    default: 4
+    inputBinding:
+      prefix: -t
+  output_sam:
+    type: string
+    label: "sam file to output results to"
+    default: "out.sam"
+    inputBinding:
+      prefix: -o
+  group_header_line:
+    type: string?
+    label: "read group header line such as '@RG\tID:foo\tSM:bar'"
+    inputBinding:
+      prefix: -R
+  index_base:
+    type: File
+    label: "fasta file for index basename"
+    inputBinding:
+      position: 1
+  amb:
+    type: File
+  ann:
+    type: File
+  bwt:
+    type: File
+  pac:
+    type: File
+  sa:
+    type: File
+  fastq_forward:
+    type: File
+    label: "input fastq file to map (single-end or forward for pair-end)"
+    inputBinding:
+      position: 2
+  fastq_reverse:
+    type: File?
+    label: "input fastq file to map (reverse for pair-end)"
+    inputBinding:
+      position: 3
+
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_sam)"
+  stdout: stdout
+  stderr: stderr
+stdout: bwa-mem-stdout.log
+stderr: bwa-mem-stderr.log

--- a/cwl/fastq2fasta-create-bwaindex.cwl
+++ b/cwl/fastq2fasta-create-bwaindex.cwl
@@ -13,9 +13,6 @@ inputs:
   threads:
     type: int
     default: 4
-  freebayes_max_coverage:
-    type: int
-    default: 200
 
 outputs:
   out_fasta:
@@ -58,6 +55,5 @@ steps:
       bam: samtools-sort/sorted_bam
       fasta: ref_fasta
       threads: threads
-      freebayes_max_coverage: freebayes_max_coverage
     out: [out_fasta]
     run: bam2fasta.cwl

--- a/cwl/fastq2fasta-create-bwaindex.cwl
+++ b/cwl/fastq2fasta-create-bwaindex.cwl
@@ -1,0 +1,63 @@
+cwlVersion: v1.1
+class: Workflow
+requirements:
+  SubworkflowFeatureRequirement: {}
+
+inputs:
+  ref_fasta:
+    type: File
+  fastq_forward:
+    type: File
+  fastq_reverse:
+    type: File?
+  threads:
+    type: int
+    default: 4
+  freebayes_max_coverage:
+    type: int
+    default: 200
+
+outputs:
+  out_fasta:
+    type: File
+    outputSource: bam2fasta/out_fasta
+
+steps:
+  bwa-index:
+    in:
+      input_fasta: ref_fasta
+    out: [amb, ann, bwt, pac, sa]
+    run: bwa-index.cwl
+  bwa-mem:
+    in:
+      threads: threads
+      fastq_forward: fastq_forward
+      fastq_reverse: fastq_reverse
+      index_base: ref_fasta
+      amb: bwa-index/amb
+      ann: bwa-index/ann
+      bwt: bwa-index/bwt
+      pac: bwa-index/pac
+      sa: bwa-index/sa
+    out: [output]
+    run: bwa-mem.cwl
+  samtools-view:
+    in:
+      threads: threads
+      input_file: bwa-mem/output
+    out: [bam]
+    run: samtools-view.cwl
+  samtools-sort:
+    in:
+      input_bamfile: samtools-view/bam
+      threads: threads
+    out: [sorted_bam]
+    run: samtools-sort.cwl
+  bam2fasta:
+    in:
+      bam: samtools-sort/sorted_bam
+      fasta: ref_fasta
+      threads: threads
+      freebayes_max_coverage: freebayes_max_coverage
+    out: [out_fasta]
+    run: bam2fasta.cwl

--- a/cwl/fastq2fasta.cwl
+++ b/cwl/fastq2fasta.cwl
@@ -1,0 +1,68 @@
+cwlVersion: v1.1
+class: Workflow
+requirements:
+  SubworkflowFeatureRequirement: {}
+
+inputs:
+  fastq_forward:
+    type: File
+  fastq_reverse:
+    type: File?
+  ref_fasta:
+    type: File
+  amb:
+    type: File
+  ann:
+    type: File
+  bwt:
+    type: File
+  pac:
+    type: File
+  sa:
+    type: File
+  threads:
+    type: int
+    default: 4
+  freebayes_max_coverage:
+    type: int
+    default: 200
+
+outputs:
+  out_fasta:
+    type: File
+    outputSource: bam2fasta/out_fasta
+
+steps:
+  bwa-mem:
+    in:
+      threads: threads
+      fastq_forward: fastq_forward
+      fastq_reverse: fastq_reverse
+      index_base: ref_fasta
+      amb: amb
+      ann: ann
+      bwt: bwt
+      pac: pac
+      sa: sa
+    out: [output]
+    run: bwa-mem.cwl
+  samtools-view:
+    in:
+      threads: threads
+      input_file: bwa-mem/output
+    out: [bam]
+    run: samtools-view.cwl
+  samtools-sort:
+    in:
+      input_bamfile: samtools-view/bam
+      threads: threads
+    out: [sorted_bam]
+    run: samtools-sort.cwl
+  bam2fasta:
+    in:
+      bam: samtools-sort/sorted_bam
+      fasta: ref_fasta
+      threads: threads
+      freebayes_max_coverage: freebayes_max_coverage
+    out: [out_fasta]
+    run: bam2fasta.cwl

--- a/cwl/fastq2fasta.cwl
+++ b/cwl/fastq2fasta.cwl
@@ -23,9 +23,6 @@ inputs:
   threads:
     type: int
     default: 4
-  freebayes_max_coverage:
-    type: int
-    default: 200
 
 outputs:
   out_fasta:
@@ -63,6 +60,5 @@ steps:
       bam: samtools-sort/sorted_bam
       fasta: ref_fasta
       threads: threads
-      freebayes_max_coverage: freebayes_max_coverage
     out: [out_fasta]
     run: bam2fasta.cwl

--- a/cwl/freebayes.cwl
+++ b/cwl/freebayes.cwl
@@ -1,0 +1,31 @@
+#!/usr/bin/env cwl-runner
+class: CommandLineTool
+cwlVersion: v1.1
+hints:
+  DockerRequirement:
+    dockerPull: "quay.io/biocontainers/freebayes:1.3.2--py37hc088bd4_0"
+baseCommand: freebayes
+arguments:
+  - --bam
+  - $(inputs.bam)
+  # - --region=$(inputs.contig):1-$(inputs.contig_end)
+  - --max-coverage
+  - $(inputs.max_coverage)
+  - -f
+  - $(inputs.ref_fasta)
+inputs:
+  - id: bam
+    type: File
+  # - id: contig
+  #   type: string
+  # - id: contig_end
+  #   type: int
+  - id: max_coverage
+    type: int
+    default: 200
+  - id: ref_fasta
+    type: File
+outputs:
+  - id: vcf
+    type: stdout
+stdout: var.vcf

--- a/cwl/freebayes.cwl
+++ b/cwl/freebayes.cwl
@@ -9,8 +9,7 @@ arguments:
   - --bam
   - $(inputs.bam)
   # - --region=$(inputs.contig):1-$(inputs.contig_end)
-  - --max-coverage
-  - $(inputs.max_coverage)
+  - --ploidy 1
   - -f
   - $(inputs.ref_fasta)
 inputs:
@@ -20,9 +19,6 @@ inputs:
   #   type: string
   # - id: contig_end
   #   type: int
-  - id: max_coverage
-    type: int
-    default: 200
   - id: ref_fasta
     type: File
 outputs:

--- a/cwl/samtools-sort.cwl
+++ b/cwl/samtools-sort.cwl
@@ -1,0 +1,41 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+doc: "samtools sort, sort given bam file"
+requirements:
+  DockerRequirement:
+    dockerPull: quay.io/biocontainers/samtools:1.9--h8571acd_11
+baseCommand: [samtools, sort]
+inputs:
+  threads:
+    type: int
+    default: 4
+    inputBinding:
+      prefix: -@
+  tmpfile:
+    type: string
+    default: sort.tmp
+    label: "Write temporary files to PREFIX.nnnn.bam"
+    inputBinding:
+      prefix: -T
+  output_bam:
+    type: string
+    default: aln.sorted.bam
+    label: "Write final output to FILENAME"
+    inputBinding:
+      prefix: -o
+  input_bamfile:
+    type: File
+    label: "Input bamfile"
+    inputBinding:
+      position: 1
+
+outputs:
+  sorted_bam:
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_bam)"
+  stdout: stdout
+  stderr: stderr
+stdout: samtools-sort-stdout.log
+stderr: samtools-sort-stderr.log

--- a/cwl/samtools-view.cwl
+++ b/cwl/samtools-view.cwl
@@ -1,0 +1,63 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+doc: "samtools view to convert sam format to bam format"
+requirements:
+  DockerRequirement:
+    dockerPull: quay.io/biocontainers/samtools:1.9--h8571acd_11
+baseCommand: [samtools, view]
+inputs:
+  threads:
+    type: int
+    label: "Number of additional threads to use"
+    default: 4
+    inputBinding:
+      prefix: -@
+  output_bam:
+    type: boolean
+    label: "output BAM"
+    default: true
+    inputBinding:
+      prefix: -b
+  output_filename:
+    type: string
+    label: "output file name"
+    default: "aln.bam"
+    inputBinding:
+      prefix: -o
+  input_file:
+    type: File
+    label: "input file"
+    inputBinding:
+      position: 1
+  include_header:
+    type: boolean
+    label: "include the header in the output"
+    default: false
+    inputBinding:
+      prefix: -h
+  ignore_previous_version:
+    type: boolean
+    label: "ignored for compatibility with previous samtools versions"
+    default: false
+    inputBinding:
+      prefix: -S
+  filter_alignments:
+    type: string?
+    label: "Do not output alignments with any bits set in INT present in the FLAG field. INT can be specified in hex by beginning with `0x' (i.e. /^0x[0-9A-F]+/) or in octal by beginning with `0' (i.e. /^0[0-7]+/) [0]."
+    inputBinding:
+      prefix: -F
+  skip_alignments:
+    type: int?
+    label: "Skip alignments with MAPQ smaller than INT [0]."
+    inputBinding:
+      prefix: -q
+outputs:
+  bam:
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_filename)"
+  stdout: stdout
+  stderr: stderr
+stdout: samtools-view-stdout.log
+stderr: samtools-view-stderr.log


### PR DESCRIPTION
Implemented three workflows:

- fastq2fasta
  - one for those who already created bwa index, map fastq and run bam2fasta
- fastq2fasta-create-bwaindex
  - create bwa index from given reference fasta before mapping, map fastq and run bam2fasta
- bam2fasta
  - variant call by freebayes, use bcftools to polish vcf and convert to fasta

All tools and workflows are confirmed by `cwltool --validate` but not yet tested with real input data.