### PR TITLE
Add docker hint, use 'id' instead of 'sequencefile' to make salad happy.

### DIFF
--- a/cwl/pangenome-generate/merge-metadata.cwl
+++ b/cwl/pangenome-generate/merge-metadata.cwl
@@ -1,5 +1,8 @@
 cwlVersion: v1.1
 class: CommandLineTool
+hints:
+  DockerRequirement:
+    dockerPull: commonworkflowlanguage/cwltool_module
 inputs:
   metadata: File[]
   metadataSchema: File

--- a/cwl/pangenome-generate/merge-metadata.py
+++ b/cwl/pangenome-generate/merge-metadata.py
@@ -12,6 +12,6 @@ subjects = $(inputs.subjects)
 
 for i, m in enumerate(metadata):
     doc, metadata = schema_salad.schema.load_and_validate(document_loader, avsc_names, m["path"], True)
-    doc["sequencefile"] = subjects[i]
+    doc["id"] = subjects[i]
     g = schema_salad.jsonld_context.makerdf(subjects[i], doc, document_loader.ctx)
     print(g.serialize(format="ntriples").decode("utf-8"))


### PR DESCRIPTION
Fixes metadata merge